### PR TITLE
Add plugin-shop class to plugin : Shop

### DIFF
--- a/View/Shop/index.ctp
+++ b/View/Shop/index.ctp
@@ -1,6 +1,6 @@
 <?= $this->Html->css('shop-homepage.css') ?>
 <?= $this->Html->css('Shop.jquery.bootstrap-touchspin.css') ?>
-<div class="container">
+<div class="container plugin-shop">
   <div class="row">
     <div class="col-md-3">
       <p class="lead"><?= ($isConnected) ? $money.' '.$Configuration->getMoneyName() : $Lang->get('SHOP__TITLE'); ?></p>

--- a/View/Shop/index.ctp
+++ b/View/Shop/index.ctp
@@ -1,4 +1,4 @@
-<?= $this->Html->css('shop-homepage.css') ?>
+<?= $this->Html->css('Shop.shop-homepage.css') ?>
 <?= $this->Html->css('Shop.jquery.bootstrap-touchspin.css') ?>
 <div class="container plugin-shop">
   <div class="row">

--- a/webroot/css/shop-homepage.css
+++ b/webroot/css/shop-homepage.css
@@ -1,0 +1,56 @@
+/*!
+ * Start Bootstrap - Shop Homepage HTML Template (http://startbootstrap.com)
+ * Code licensed under the Apache License v2.0.
+ * For details, see http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+
+.plugin-shop{
+    padding-top: 70px;
+    padding-bottom: 50px;
+}
+
+.plugin-shop .slide-image {
+    width: 100%;
+}
+
+.plugin-shop .carousel-holder {
+    margin-bottom: 30px;
+}
+
+.plugin-shop .carousel-control,
+.plugin-shop .item {
+    border-radius: 4px;
+}
+
+.plugin-shop .caption {
+    height: 130px;
+    overflow: hidden;
+}
+
+.plugin-shop .caption h4 {
+    white-space: nowrap;
+}
+
+.plugin-shop .thumbnail img {
+    width: 100%;
+    height: 113px;
+    margin: 0 auto;
+    display: block;
+}
+
+.plugin-shop .ratings {
+    padding-right: 10px;
+    padding-left: 10px;
+    color: #d17581;
+}
+
+.plugin-shop .thumbnail {
+    padding: 0;
+}
+
+.plugin-shop .thumbnail .caption-full {
+    padding: 9px;
+    color: #333;
+}
+


### PR DESCRIPTION
Comme ça on va pouvoir : 

- Modifier le CSS du plugin Shop sans devoir obligatoirement posséder les vues dans le thème (c'est toujours utile)
- Ajouter du style au container du plugin sans devoir toucher le body (à bon entendeur)

PS : Le CSS est dans le webroot du CMS et pas dans le dossier du plugin et ça c'est chiant