### PR TITLE
Modification

### DIFF
--- a/View/Shop/admin_add_item.ctp
+++ b/View/Shop/admin_add_item.ctp
@@ -165,7 +165,7 @@
 
             <div class="form-group">
               <div class="checkbox">
-                <input name="display" type="checkbox">
+                <input name="display" type="checkbox" checked="checked">
                 <label><?= $Lang->get('SHOP__ITEM_CHECKBOX_DISPLAY') ?></label>
               </div>
             </div>


### PR DESCRIPTION
Quand on ajoute un article sur la boutique, on oublie très souvent de cocher "Afficher l'article sur la boutique", c'est très chiant et dans mon cas quand je refais ma boutique et que j'ajoute 20 articles et que j'oublie ça sur les 20 = perte de temps...